### PR TITLE
Fix a bug while using solver renormalization.

### DIFF
--- a/lib/solve.cpp
+++ b/lib/solve.cpp
@@ -146,7 +146,7 @@ namespace quda
     // rescale the source and solution vectors to help prevent the onset of underflow
     if (param.solver_normalization == QUDA_SOURCE_NORMALIZATION) {
       auto nb_inv(nb);
-      for (auto bi : nb_inv) bi = 1 / sqrt(bi);
+      for (auto &bi : nb_inv) bi = 1 / sqrt(bi);
       blas::ax(nb_inv, b);
       blas::ax(nb_inv, x);
     }
@@ -299,7 +299,7 @@ namespace quda
 
     if (param.solver_normalization == QUDA_SOURCE_NORMALIZATION) {
       // rescale the solution
-      for (auto bi : nb) bi = sqrt(bi);
+      for (auto &bi : nb) bi = sqrt(bi);
       blas::ax(nb, x);
     }
 


### PR DESCRIPTION
The solver normalization is incorrect as we don't actually change values in `nb_inv` and `nb`. Using the reference of the vector element instead.